### PR TITLE
Update Caddy to v0.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 MAINTAINER Thibault NORMAND <me@zenithar.org>
 
 ENV GOPATH /go
-ENV CADDY_TAG v0.9.5
+ENV CADDY_TAG v0.10.4
 
 RUN apk add --update musl \
     && apk add -t build-tools build-base go mercurial git \


### PR DESCRIPTION
Thank you for sharing this image! It's really useful.

The current Caddy version is 0.10.4, which brings a lot of useful improvements (in particular I'm interested in `{~cookie}` placeholders).

Would you mind updating and publishing a new image on Docker Hub?

Thanks!